### PR TITLE
Added note to load the GlobalAuth component

### DIFF
--- a/docs/behaviors/whodidit.md
+++ b/docs/behaviors/whodidit.md
@@ -3,6 +3,8 @@ WhoDidIt-Behavior
 
 The WhoDidIt-Behavior can be used to know who created, and who modified a specific post. 
 
+To use this Behaviour you will need to load the GlobalAuth component.
+
 [doc_toc]
 
 Loading


### PR DESCRIPTION
This Behaviour uses the GlobalAuth component for getting the authorized user's ID, so without loading that it will save NULL to the modified_by and created_by fields. Added a note to load that component.
